### PR TITLE
Add Terraform configuration for GCP VM provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,11 @@ build/
 
 discord-issue-bot/data/history.json
 discord-issue-bot/uv.lock
+
+# Terraform state and variables
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/terraform.tfstate
+terraform/terraform.tfstate.*
+terraform/terraform.tfvars
+terraform/*.tfstate.backup

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,75 @@
+# Google Cloud VM Terraform Configuration
+
+This Terraform configuration provisions a single Google Compute Engine VM along with the networking resources required for SSH access. The files are organised so you can quickly provide your own project details, credentials, and SSH key to bring the instance online.
+
+## 📁 Repository Layout
+
+- `main.tf` – Core infrastructure resources (network, firewall, static IP, Compute Engine instance).
+- `variables.tf` – Input variables used to customise the deployment.
+- `outputs.tf` – Helpful values such as the external IP address and an SSH command template.
+- `terraform.tfvars.example` – Sample variable definitions; copy to `terraform.tfvars` and update with your environment-specific values.
+
+## ✅ Prerequisites
+
+1. **Terraform** v1.3.0 or later installed locally.
+2. **Google Cloud project** with the Compute Engine API enabled.
+3. **Service account** JSON key with permissions to manage Compute Engine, VPC networks, and firewall rules. Store the key securely and reference its path via the `credentials_file` variable.
+4. **SSH key pair** (OpenSSH format). Supply the public key and the username that should own it on the VM.
+
+## 🚀 Usage
+
+1. Move into the Terraform directory in this repository:
+
+   ```bash
+   cd terraform
+   ```
+
+2. Copy the example variables file and customise the values:
+
+   ```bash
+   cp terraform.tfvars.example terraform.tfvars
+   # Edit terraform.tfvars with your editor of choice
+   ```
+
+3. Initialise the Terraform working directory:
+
+   ```bash
+   terraform init
+   ```
+
+4. Review the planned infrastructure changes:
+
+   ```bash
+   terraform plan
+   ```
+
+5. Apply the configuration to create the resources:
+
+   ```bash
+   terraform apply
+   ```
+
+   Confirm the apply when prompted. Terraform will output the VM's public IP and a ready-to-use SSH command once provisioning completes.
+
+6. SSH into the VM using the command displayed in the outputs:
+
+   ```bash
+   ssh <ssh_username>@<public_ip>
+   ```
+
+## 🔒 Security Notes
+
+- Restrict `ssh_source_ranges` to trusted IP address ranges whenever possible instead of leaving it open to the internet.
+- Rotate or revoke the service account key when it is no longer needed.
+- If you provide a startup script, ensure it only performs actions you trust.
+
+## 🧹 Clean-up
+
+When you are finished testing, destroy the infrastructure to avoid ongoing charges:
+
+```bash
+terraform destroy
+```
+
+Confirm the destroy when prompted to remove all resources that were created.
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,90 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+
+  credentials = var.credentials_file != "" ? file(var.credentials_file) : null
+}
+
+data "google_compute_default_service_account" "default" {
+  project = var.project_id
+}
+
+resource "google_compute_network" "vm_network" {
+  name                    = var.network_name
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "vm_subnetwork" {
+  name          = "${var.network_name}-subnet"
+  ip_cidr_range = var.subnetwork_cidr
+  region        = var.region
+  network       = google_compute_network.vm_network.id
+}
+
+resource "google_compute_firewall" "ssh" {
+  name    = "${var.network_name}-allow-ssh"
+  network = google_compute_network.vm_network.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  direction     = "INGRESS"
+  priority      = 1000
+  source_ranges = var.ssh_source_ranges
+  target_tags   = [var.network_tag]
+}
+
+resource "google_compute_address" "vm_ip" {
+  name   = "${var.instance_name}-ip"
+  region = var.region
+}
+
+resource "google_compute_instance" "vm" {
+  name         = var.instance_name
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = var.boot_image
+      size  = var.boot_disk_size_gb
+      type  = var.boot_disk_type
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.vm_subnetwork.id
+
+    access_config {
+      nat_ip = google_compute_address.vm_ip.address
+    }
+  }
+
+  tags = [var.network_tag]
+
+  metadata = {
+    "ssh-keys" = "${var.ssh_username}:${var.ssh_public_key}"
+  }
+
+  service_account {
+    email  = data.google_compute_default_service_account.default.email
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+
+  metadata_startup_script = var.startup_script != "" ? var.startup_script : null
+}
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "instance_name" {
+  description = "Name of the created Compute Engine instance."
+  value       = google_compute_instance.vm.name
+}
+
+output "instance_public_ip" {
+  description = "Ephemeral public IP address assigned to the instance."
+  value       = google_compute_address.vm_ip.address
+}
+
+output "ssh_command" {
+  description = "Convenience SSH command that can be used once the instance is provisioned."
+  value       = "ssh ${var.ssh_username}@${google_compute_address.vm_ip.address}"
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,18 @@
+# Copy this file to terraform.tfvars and update the values with your environment-specific settings.
+project_id        = "my-gcp-project-id"
+credentials_file  = "~/secrets/my-gcp-service-account.json"
+region            = "asia-northeast1"
+zone              = "asia-northeast1-a"
+instance_name     = "baby-monitor-vm"
+machine_type      = "e2-micro"
+network_name      = "baby-monitor-network"
+subnetwork_cidr   = "10.10.0.0/24"
+ssh_source_ranges = ["203.0.113.0/24"]
+network_tag       = "baby-monitor-ssh"
+ssh_username      = "gcpuser"
+ssh_public_key    = "ssh-ed25519 AAAA... user@example.com"
+startup_script    = <<-EOT
+  #!/bin/bash
+  apt-get update -y
+  apt-get install -y google-cloud-sdk
+EOT

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,92 @@
+variable "project_id" {
+  description = "The ID of the Google Cloud project where resources will be created."
+  type        = string
+}
+
+variable "credentials_file" {
+  description = "Optional path to a Google Cloud service account JSON key with sufficient permissions. Leave blank to use Application Default Credentials."
+  type        = string
+  default     = ""
+}
+
+variable "region" {
+  description = "Google Cloud region to deploy networking resources in."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "Google Cloud zone to deploy the compute instance in."
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "instance_name" {
+  description = "Name of the Compute Engine instance."
+  type        = string
+  default     = "terraform-managed-vm"
+}
+
+variable "machine_type" {
+  description = "Compute Engine machine type for the instance."
+  type        = string
+  default     = "e2-micro"
+}
+
+variable "boot_image" {
+  description = "Source image used to initialize the VM's boot disk."
+  type        = string
+  default     = "debian-cloud/debian-12"
+}
+
+variable "boot_disk_size_gb" {
+  description = "Size of the VM boot disk in GB."
+  type        = number
+  default     = 10
+}
+
+variable "boot_disk_type" {
+  description = "Type of disk to use for the boot disk."
+  type        = string
+  default     = "pd-balanced"
+}
+
+variable "network_name" {
+  description = "Name of the VPC network that will host the VM."
+  type        = string
+  default     = "terraform-vm-network"
+}
+
+variable "subnetwork_cidr" {
+  description = "CIDR block for the custom subnetwork."
+  type        = string
+  default     = "10.0.0.0/24"
+}
+
+variable "ssh_source_ranges" {
+  description = "List of CIDR blocks that are allowed to reach the VM over SSH."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "network_tag" {
+  description = "Network tag applied to the VM for firewall targeting."
+  type        = string
+  default     = "terraform-vm"
+}
+
+variable "ssh_username" {
+  description = "Linux username that will own the uploaded SSH public key."
+  type        = string
+}
+
+variable "ssh_public_key" {
+  description = "Public SSH key (in OpenSSH format) that will be added to the VM metadata."
+  type        = string
+}
+
+variable "startup_script" {
+  description = "Optional startup script executed the first time the instance boots."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- add Terraform configuration that provisions a Compute Engine VM with dedicated networking, firewall, and SSH metadata
- define reusable variables, outputs, and sample tfvars for easy customisation
- document setup steps and ignore Terraform state files in version control

## Testing
- not run (Terraform CLI is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf39de28f8832cb297f57148f10114