### PR TITLE
chore: externalize terraform startup script

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+apt-get update -y
+apt-get install -y google-cloud-sdk

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -15,9 +15,5 @@ ssh_public_key      = ""
 ssh_public_key_file = "~/.ssh/id_ed25519.pub"
 
 # startup_script が空の場合は startup_script_file が読み込まれるよ。
-# startup_script_file = "./scripts/startup.sh"
-startup_script = <<-EOT
-  #!/bin/bash
-  apt-get update -y
-  apt-get install -y google-cloud-sdk
-EOT
+startup_script      = ""
+startup_script_file = "./scripts/startup.sh"


### PR DESCRIPTION
## Summary
- add scripts/startup.sh to hold the VM bootstrap commands
- point terraform.tfvars.example at the new startup script file instead of an inline heredoc

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf43fe9484832caa0c211e934db7df